### PR TITLE
Correct fedramp-version examples, finish release guidance alignment

### DIFF
--- a/content/documentation/general-concepts/4-expressing-common-fedramp-template-elements-in-oscal.md
+++ b/content/documentation/general-concepts/4-expressing-common-fedramp-template-elements-in-oscal.md
@@ -59,7 +59,7 @@ OR
     <last-modified>2023-03-03T00:00:00.000Z </last-modified>
     <version>0.0</version>
     <oscal-version>1.1.2</oscal-version>
-    <prop name="fedramp-version" ns="https://fedramp.gov/ns/oscal" value="fedramp-3.0.0rc1-oscal-1.1.2"/>
+    <prop name="fedramp-version" ns="https://fedramp.gov/ns/oscal" value="3.0.0-rc1"/>
     <prop name="marking" value="cui"/>
     <role id="fedramp-pmo">
         <title>FedRAMP PMO</title>
@@ -382,7 +382,7 @@ FedRAMP maintains an official list of the versions on the [fedramp-automation re
     <last-modified>2023-03-03T00:00:00.000Z </last-modified>
     <version>0.0</version>
     <oscal-version>1.1.2</oscal-version>
-    <prop name="fedramp-version" ns="https://fedramp.gov/ns/oscal" value="fedramp-3.0.0rc1-oscal-1.1.2"/>
+    <prop name="fedramp-version" ns="https://fedramp.gov/ns/oscal" value="3.0.0-rc1"/>
 </metadata>
 {{</ highlight >}}
 


### PR DESCRIPTION
Brian and others pointed out yesterday that I had missed the examples in the site itself. This should wrap up website changes for GSA/fedramp-automation#847.