### PR TITLE
Remove obsolete CRM data for #807 tasks

### DIFF
--- a/content/documentation/ssp/4-ssp-template-to-oscal-mapping.md
+++ b/content/documentation/ssp/4-ssp-template-to-oscal-mapping.md
@@ -953,8 +953,6 @@ While a leveraged system has no need to represent content here, its SSP must inc
         <prop ns="https://fedramp.gov/ns/oscal" name="authorization-type" 
               value="fedramp-agency"/>
         <prop ns="https://fedramp.gov/ns/oscal" name="impact-level" value="moderate"/>
-        <link href="//path/to/leveraged_system_legacy_crm.xslt" />
-        <link href="//path/to/leveraged_system_responsibility_and_inheritance.xml" />
         <party-uuid>uuid-of-leveraged-system-poc</party-uuid>
         <date-authorized>2015-01-01</date-authorized>
     </leveraged-authorization>


### PR DESCRIPTION
This change is not directly related to any one constraint task, but this information in the website is no longer correct that pertains to multiple constraint tasks in the GSA/fedramp-automation#807 epic.