### PR TITLE
Add documentation for external systems

### DIFF
--- a/content/documentation/ssp/4-ssp-template-to-oscal-mapping.md
+++ b/content/documentation/ssp/4-ssp-template-to-oscal-mapping.md
@@ -1033,47 +1033,6 @@ Replace XPath predicate "[1]" with "[2]", "[3]", etc.
 
 ---
 
-## External Systems
-
-For external systems, a FedRAMP SSP must specify the type of an agreement between the documented system and any external system documented in the SSP.
-
-The nature-of-agreement property identifies the acceptable agreement types.
-
-#### OSCAL Representation
-{{< highlight xml "linenos=table" >}}
-<system-implementation>
-    <component uuid="uuid-of-external-system" type="system">
-      <title>Name of The External System</title>
-      <description>
-          <p>Briefly describe the external system.</p>
-      </description>
-      <prop name="inherited-uuid" value="11111111-0000-4000-9001-000000000001"/>
-      <prop name="implementation-point" value="external"/>
-      <prop name="nature-of-agreement" ns="https://fedramp.gov/ns/oscal" value="isa"/>
-      <status state="operational"/>
-    </component>
-</system-implementation>
-{{</ highlight >}}
-
-<br/>
-
-{{<callout>}}
-
-**FedRAMP Allowed Values**
-
-FedRAMP defines the following allowed values for the nature-of-agreement property:
-- contract
-- eula
-- isa
-- license
-- mou
-- other
-- sla
-
-{{</callout>}}
-
----
-
 ## Users
 
 A FedRAMP SSP must identify the users of the system by type, privilege, sensitivity level, the ID of the associated role, and a list of one or more authorized privileges.  The SSP must also provide the authentication method(s) used for each identified user.
@@ -1171,14 +1130,16 @@ count(/*/system-implementation/user[1]/authorized-privilege[1]/function-performe
 
 ## External Systems and Services Not Having FedRAMP Authorization
 
-FedRAMP authorized services should be used, whenever possible, since their risk is defined.  However, there are instances where CSOs have external systems or services that are not FedRAMP authorized.  In OSCAL, these external systems and services must be identified using `component` assemblies with additional FedRAMP namespace and class properties as shown in the OSCAL representation below.  
+FedRAMP authorized services should be used, whenever possible, since their risk is defined.  However, there are instances where CSOs have external systems or services that are not FedRAMP authorized.  In OSCAL, these external systems and services must be identified using `component` assemblies with additional FedRAMP namespace and class properties as shown in the OSCAL representation below.
+
+The nature-of-agreement property identifies acceptable agreement types.
 
 {{< figure src="/img/ssp-figure-17.png" title="FedRAMP SSP template external systems (not FedRAMP authorized)." alt="Screenshot of the external system information for non-FedRAMP authorized services in the FedRAMP SSP template." >}}
 
 #### OSCAL Representation
 {{< highlight xml "linenos=table" >}}
 <!-- list any external connections as components in the system-characteristics -->
-<component uuid="uuid-value" type="interconnection">
+<component uuid="uuid-value" type="system">
     <title>[EXAMPLE]External System / Service Name</title>
     <description>
         <p>Briefly describe the interconnection details.</p>
@@ -1219,6 +1180,7 @@ FedRAMP authorized services should be used, whenever possible, since their risk 
         <prop ns="https://fedramp.gov/ns/oscal" name="port" class="remote" value="80"/>
         <prop ns="https://fedramp.gov/ns/oscal" name="interconnection-security" 
             value="ipsec">
+        <prop name="nature-of-agreement" ns="https://fedramp.gov/ns/oscal" value="isa"/>
                 <!-- cut ports, protocols -->
     <link href="#uuid-of-ICA-resource-in-back-matter" rel="isa-agreement" />                                    
     <!-- cut repeat responsible-party assembly for each required ICA role id -->
@@ -1234,6 +1196,25 @@ FedRAMP authorized services should be used, whenever possible, since their risk 
     <!-- repeat citation assembly for each ICA -->
 </back-matter>
 {{</ highlight >}}
+
+<br/>
+
+{{<callout>}}
+
+**FedRAMP Allowed Values**
+
+FedRAMP defines the following allowed values for the nature-of-agreement property:
+- contract
+- eula
+- isa
+- license
+- mou
+- other
+- sla
+
+{{</callout>}}
+
+<br/>
 
 ### External System and Services (Queries)
 

--- a/content/documentation/ssp/4-ssp-template-to-oscal-mapping.md
+++ b/content/documentation/ssp/4-ssp-template-to-oscal-mapping.md
@@ -913,7 +913,7 @@ Each system must define at least two data centers. There must be exactly one pri
 {{</ highlight >}}
 
 ---
-## Leveraged FedRAMP-authorized Services
+## Leveraged FedRAMP-Authorized Services
 
 If this system is leveraging the authorization of one or more systems, such as a SaaS running on an IaaS, each leveraged system must be represented within the system-implementation assembly. There must be one leveraged-authorization assembly and one matching component assembly for each leveraged authorization.
 
@@ -949,7 +949,7 @@ While a leveraged system has no need to represent content here, its SSP must inc
         <!-- FedRAMP Package ID -->
         <prop name="leveraged-system-identifier" 
             ns="https://fedramp.gov/ns/oscal" 
-            value="Package_ID value" />
+            value="Package_ID value"/>
         <prop ns="https://fedramp.gov/ns/oscal" name="authorization-type" 
               value="fedramp-agency"/>
         <prop ns="https://fedramp.gov/ns/oscal" name="impact-level" value="moderate"/>
@@ -957,14 +957,14 @@ While a leveraged system has no need to represent content here, its SSP must inc
         <date-authorized>2015-01-01</date-authorized>
     </leveraged-authorization>
     <!-- CSO name & service description -->
-    <component uuid="uuid-of-leveraged-system" type="leveraged-system">
+    <component uuid="uuid-of-leveraged-system" type="system">
         <title>Name of Leveraged System</title>
         <description>
             <p>Briefly describe leveraged system.</p>
         </description>
         <prop name="leveraged-authorization-uuid" 
-              value="5a9c98ab-8e5e-433d-a7bd-515c07cd1497" />
-        <prop name="inherited-uuid" value="11111111-0000-4000-9001-000000000001" />
+              value="5a9c98ab-8e5e-433d-a7bd-515c07cd1497"/>
+        <prop name="inherited-uuid" value="11111111-0000-4000-9001-000000000001"/>
         <prop name="nature-of-agreement" ns="https://fedramp.gov/ns/oscal" value="sla"/>
         <prop name="implementation-point" value="external"/>
         <!-- FedRAMP prop extensions for table 6.1 columns -->
@@ -983,6 +983,8 @@ A leveraged-system-identifier property must be provided within each leveraged-au
 The nature-of-agreement property identifies the appropriate type of agreement between the documented system and its leveraged authorizations documented in an SSP.
 
 {{</callout>}}
+
+<br/>
 
 {{<callout>}}
 
@@ -1027,6 +1029,47 @@ FedRAMP defines the following allowed values for the nature-of-agreement propert
 <br />
 {{<callout>}}
 Replace XPath predicate "[1]" with "[2]", "[3]", etc.
+{{</callout>}}
+
+---
+
+## External Systems
+
+For external systems, a FedRAMP SSP must specify the type of an agreement between the documented system and any external system documented in the SSP.
+
+The nature-of-agreement property identifies the acceptable agreement types.
+
+#### OSCAL Representation
+{{< highlight xml "linenos=table" >}}
+<system-implementation>
+    <component uuid="uuid-of-external-system" type="system">
+      <title>Name of The External System</title>
+      <description>
+          <p>Briefly describe the external system.</p>
+      </description>
+      <prop name="inherited-uuid" value="11111111-0000-4000-9001-000000000001"/>
+      <prop name="implementation-point" value="external"/>
+      <prop name="nature-of-agreement" ns="https://fedramp.gov/ns/oscal" value="isa"/>
+      <status state="operational"/>
+    </component>
+</system-implementation>
+{{</ highlight >}}
+
+<br/>
+
+{{<callout>}}
+
+**FedRAMP Allowed Values**
+
+FedRAMP defines the following allowed values for the nature-of-agreement property:
+- contract
+- eula
+- isa
+- license
+- mou
+- other
+- sla
+
 {{</callout>}}
 
 ---


### PR DESCRIPTION
On the **FedRAMP SSP Contents** page, add the **External Systems** section, which includes description and allowed values for the `nature-of-agreement` property.

Related issue [#907](https://github.com/GSA/fedramp-automation/issues/907)

Related PR [#929](https://github.com/GSA/fedramp-automation/pull/929)